### PR TITLE
docs: update footer to KULSOFT.NET LLC copyright

### DIFF
--- a/index.html
+++ b/index.html
@@ -427,8 +427,9 @@
 
 <!-- ── Footer ─────────────────────────────────────────────── -->
 <footer>
-  <p>Copyright &copy; 2026 Prateep Kul &mdash; All rights reserved.</p>
-  <p style="margin-top:.4rem;">
+  <p>&copy; 2026 KULSOFT.NET LLC. All rights reserved.</p>
+  <p style="margin-top:.25rem;">Owned and operated by Prateep Kul.</p>
+  <p style="margin-top:.6rem;">
     <a href="LICENSE.TXT">License</a> &nbsp;·&nbsp;
     <a href="https://github.com/kul1/jindai_download/releases">Releases</a> &nbsp;·&nbsp;
     <a href="https://github.com/kul1/jindai_download/issues">Issues</a> &nbsp;·&nbsp;


### PR DESCRIPTION
## Summary

Replaces the current footer copyright line with the requested corporate form:

**Before**
> Copyright © 2026 Prateep Kul — All rights reserved.

**After**
> © 2026 KULSOFT.NET LLC. All rights reserved.
> Owned and operated by Prateep Kul.

License / Releases / Issues / Support links are unchanged.

## Test plan

- [x] `index.html` diff reviewed — only the two `<p>` tags inside `<footer>` changed
- [x] No CSS / script touched
- [x] GitHub Pages will rebuild automatically on merge to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)