### PR TITLE
docs: add 'by Kulsoft.Net LLC.' credit next to JindAI wordmark

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,8 +32,26 @@
       border-bottom: 1px solid var(--border);
       position: sticky; top: 0; background: var(--bg); z-index: 100;
     }
-    .logo { font-size: 1.25rem; font-weight: 700; letter-spacing: -0.02em; }
+    .logo {
+      font-size: 1.25rem; font-weight: 700; letter-spacing: -0.02em;
+      display: flex; align-items: baseline; gap: .5rem;
+    }
     .logo span { color: var(--accent); }
+    /* "by Kulsoft.Net LLC." — deliberately different face + weight so it
+       reads as a credit line rather than part of the wordmark. */
+    .logo-by {
+      font-family: Georgia, "Times New Roman", serif;
+      font-size: .78rem;
+      font-weight: 400;
+      font-style: italic;
+      letter-spacing: .01em;
+      color: var(--muted);
+    }
+    .logo-by b {
+      font-weight: 600;
+      font-style: normal;
+      color: var(--text);
+    }
     nav ul { list-style: none; display: flex; gap: 2rem; }
     nav a { color: var(--muted); text-decoration: none; font-size: 0.9rem; }
     nav a:hover { color: var(--text); }
@@ -217,7 +235,10 @@
 
 <!-- ── Navigation ─────────────────────────────────────────── -->
 <nav>
-  <div class="logo">Jind<span>AI</span></div>
+  <div class="logo">
+    Jind<span>AI</span>
+    <span class="logo-by">by <b>Kulsoft.Net LLC.</b></span>
+  </div>
   <ul>
     <li><a href="#install">Install</a></li>
     <li><a href="#cli">CLI</a></li>


### PR DESCRIPTION
## Summary

Extends the sticky nav header so the JindAI wordmark now reads:

> **Jind**`AI` _by_ **Kulsoft.Net LLC.**

The credit is intentionally styled differently from the wordmark so it
reads as a credit line rather than part of the product name:

| Part              | Font                   | Weight | Style     | Color      |
|-------------------|------------------------|--------|-----------|------------|
| `Jind`/`AI`       | (inherits — sans)      | 700    | normal    | text/accent |
| `by`              | Georgia / Times serif  | 400    | italic    | muted      |
| `Kulsoft.Net LLC.`| Georgia / Times serif  | 600    | normal    | text       |

Uses a new isolated `.logo-by` CSS class so future nav changes don't
affect the credit line.

## Test plan

- [x] Only `.logo` / `.logo-by` CSS and the `<div class="logo">` markup changed
- [x] No JavaScript, no footer, no hero copy touched
- [x] GitHub Pages will rebuild automatically on merge to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)