### PR TITLE
docs: remove 'Owned and operated by Prateep Kul.' from footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -449,7 +449,6 @@
 <!-- ── Footer ─────────────────────────────────────────────── -->
 <footer>
   <p>&copy; 2026 KULSOFT.NET LLC. All rights reserved.</p>
-  <p style="margin-top:.25rem;">Owned and operated by Prateep Kul.</p>
   <p style="margin-top:.6rem;">
     <a href="LICENSE.TXT">License</a> &nbsp;·&nbsp;
     <a href="https://github.com/kul1/jindai_download/releases">Releases</a> &nbsp;·&nbsp;


### PR DESCRIPTION
## Summary

The header now carries *"JindAI by Kulsoft.Net LLC."* so repeating the
owner attribution in the footer is redundant.  This drops the
`<p>Owned and operated by Prateep Kul.</p>` line and keeps only the
primary copyright:

> © 2026 KULSOFT.NET LLC. All rights reserved.

## Test plan

- [x] Only one `<p>` line removed — no other footer / header / CSS / JS touched
- [x] GitHub Pages will rebuild on merge to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)